### PR TITLE
Fix absolute positioning bug in osc_impendance

### DIFF
--- a/deoxys/franka-interface/src/controllers/osc_impedance.cpp
+++ b/deoxys/franka-interface/src/controllers/osc_impedance.cpp
@@ -89,10 +89,11 @@ void OSCImpedanceController::ComputeGoal(
         Eigen::Quaterniond(relative_axis_angle.toRotationMatrix() *
                            current_state_info->quat_EE_in_base_frame);
   } else {
-    goal_state_info->pos_EE_in_base_frame =
-        current_state_info->pos_EE_in_base_frame +
-        Eigen::Vector3d(control_msg_.goal().x(), control_msg_.goal().y(),
-                        control_msg_.goal().z());
+    goal_state_info->pos_EE_in_base_frame = Eigen::Vector3d(
+        control_msg_.goal().x(),
+        control_msg_.goal().y(),
+        control_msg_.goal().z()
+    );
     Eigen::AngleAxisd absolute_axis_angle;
     Eigen::Vector3d absolute_ori(control_msg_.goal().ax(),
                                  control_msg_.goal().ay(),


### PR DESCRIPTION
Note: I'm brand new to this framework, so please make sure that this change makes sense to you too. I've been running this code for a couple of days (with is_delta=False and action_scale.translation=1.0 configured) and it seems to work well.

-- original commit message --

UT-Austin-RPL/deoxys_control#3

Removes the term that adds the current end-effector position to the translation action in the section of ComputeGoal that is exectued if `is_delta=False`.