### PR TITLE
Use FR3 joint position and velocity limits in place of Panda

### DIFF
--- a/deoxys/franka-interface/include/utils/common_utils.h
+++ b/deoxys/franka-interface/include/utils/common_utils.h
@@ -48,8 +48,13 @@ private:
 
   double time_ = 0.0;
 
+  // FR3 (Franka Research 3) per-joint velocity limits per the URDF /
+  // FCI docs. The previous values (2.0/2.0/2.0/2.0/2.5/2.5/2.5) exceed
+  // FR3 on joints 2/3/4/6, so the trajectory planner could emit
+  // velocities that libfranka rejects mid-motion, throwing inside the
+  // 1 kHz control thread.
   Vector7d dq_max_ =
-      (Vector7d() << 2.0, 2.0, 2.0, 2.0, 2.5, 2.5, 2.5).finished();
+      (Vector7d() << 2.0, 1.0, 1.5, 1.25, 3.0, 1.5, 3.0).finished();
   Vector7d ddq_max_start_ = (Vector7d() << 5, 5, 5, 5, 5, 5, 5).finished();
   Vector7d ddq_max_goal_ = (Vector7d() << 5, 5, 5, 5, 5, 5, 5).finished();
 };

--- a/deoxys/franka-interface/include/utils/traj_interpolators/smooth_joint_traj_interpolator.h
+++ b/deoxys/franka-interface/include/utils/traj_interpolators/smooth_joint_traj_interpolator.h
@@ -23,8 +23,10 @@ private:
   Vector7d t_f_sync_;
   Vector7d q_1_;
 
+  // FR3 (Franka Research 3) per-joint velocity limits per the URDF /
+  // FCI docs. See common_utils.h for rationale.
   Vector7d dq_max_ =
-      (Vector7d() << 2.0, 2.0, 2.0, 2.0, 2.5, 2.5, 2.5).finished();
+      (Vector7d() << 2.0, 1.0, 1.5, 1.25, 3.0, 1.5, 3.0).finished();
   Vector7d ddq_max_start_ = (Vector7d() << 1, 1, 1, 1, 1, 1, 1).finished();
   Vector7d ddq_max_goal_ = (Vector7d() << 1, 1, 1, 1, 1, 1, 1).finished();
 

--- a/deoxys/franka-interface/src/controllers/joint_impedance.cpp
+++ b/deoxys/franka-interface/src/controllers/joint_impedance.cpp
@@ -58,8 +58,13 @@ bool JointImpedanceController::ParseMessage(const FrankaControlMessage &msg) {
   Kp << Eigen::Map<const Eigen::Matrix<double, 7, 1>>(kp_array.data());
   Kd << Eigen::Map<const Eigen::Matrix<double, 7, 1>>(kd_array.data());
 
-  joint_max_ << 2.8978, 1.7628, 2.8973, -0.0698, 2.8973, 3.7525, 2.8973;
-  joint_min_ << -2.8973, -1.7628, -2.8973, -3.0718, -2.8973, -0.0175, -2.8973;
+  // FR3 (Franka Research 3) joint limits per the URDF / FCI docs.
+  // Originally these were Panda limits, which let commands pass the deoxys
+  // zero-torque guard but trip libfranka's tighter internal check on FR3
+  // hardware. The resulting throw inside the 1 kHz control thread aborts
+  // with "terminate called without an active exception".
+  joint_max_ <<  2.3093,  1.5133,  2.4937, -0.4461,  2.4800,  4.2094,  2.6895;
+  joint_min_ << -2.3093, -1.5133, -2.4937, -2.7478, -2.4800,  0.8521, -2.6895;
 
   this->state_estimator_ptr_->ParseMessage(msg.state_estimator_msg());
   return true;

--- a/deoxys/franka-interface/src/controllers/osc_impedance.cpp
+++ b/deoxys/franka-interface/src/controllers/osc_impedance.cpp
@@ -55,8 +55,10 @@ bool OSCImpedanceController::ParseMessage(const FrankaControlMessage &msg) {
   static_q_task_ << 0.09017809387254755, -0.9824203501652151,
       0.030509718397568178, -2.694229634937343, 0.057700675144720104,
       1.860298714876101, 0.8713759453244422;
-  joint_max_ << 2.8978, 1.7628, 2.8973, -0.0698, 2.8973, 3.7525, 2.8973;
-  joint_min_ << -2.8973, -1.7628, -2.8973, -3.0718, -2.8973, -0.0175, -2.8973;
+  // FR3 (Franka Research 3) joint limits per the URDF / FCI docs.
+  // See joint_impedance.cpp for the full rationale.
+  joint_max_ <<  2.3093,  1.5133,  2.4937, -0.4461,  2.4800,  4.2094,  2.6895;
+  joint_min_ << -2.3093, -1.5133, -2.4937, -2.7478, -2.4800,  0.8521, -2.6895;
   avoidance_weights_ << 1., 1., 1., 1., 1., 10., 10.;
 
   std::vector<double> residual_mass_array;


### PR DESCRIPTION
The hard-coded joint limit tables in joint_impedance.cpp, osc_impedance.cpp, common_utils.h, and smooth_joint_traj_interpolator.h were Panda values, not Franka Research 3 ones. On FR3 hardware:

- Joint 6's Panda lower limit (-0.0175) is ~0.87 rad below FR3's hard lower (+0.8521). Commands below ~0.85 pass deoxys's clipping but trip libfranka, which rejects them.
- Joint 4's Panda lower (-3.0718) sits 0.32 rad below FR3's -2.7478.
- Joints 1/2/3/5/7 each have 0.4-0.6 rad of "deoxys-safe / libfranka- rejects" gap on each side.
- dq_max in the trajectory interpolators (2.0/2.0/2.0/2.0/2.5/2.5/2.5) exceeds FR3 limits on joints 2/3/4/6.

libfranka's rejection throws a franka::ControlException inside the 1 kHz control thread. The exception isn't caught at the thread boundary, the thread terminates while joinable, and the main destructor chain then aborts with "terminate called without an active exception". Updating the four tables to FR3 values (matching the official URDF and FCI documentation) eliminates the throw path on FR3 hardware.